### PR TITLE
fix(scripts): Do not word split file paths that include whitespace

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,7 +8,7 @@
 #bail out on error
 set -e
 
-me=$(basename $0)
+me=$(basename "$0")
 
 for prog in aclocal autoheader automake autoconf make; do
    if ! which $prog >/dev/null 2>&1 ; then

--- a/cppcheck/run_cppcheck.sh
+++ b/cppcheck/run_cppcheck.sh
@@ -2,24 +2,24 @@
 
 set -eu
 
-outdir=$(dirname $0)/out
-me=$(basename $0)
+outdir=$(dirname "$0")/out
+me=$(basename "$0")
 
-mkdir -p $outdir
+mkdir -p "$outdir"
 
 args="--enable=all --inconclusive --std=c++11 -I . --quiet --suppress=missingIncludeSystem"
 
 # cppcheck can not produce an xml report and a reulgar text file at the same time, so run twice
-cppcheck $args *.cc *.hh --template='{severity}:{file}:{line}:{message}' 2>$outdir/cppcheck.out
+cppcheck $args *.cc *.hh --template='{severity}:{file}:{line}:{message}' 2>"$outdir/cppcheck.out"
 
-cppcheck $args *.cc *.hh --xml 2>$outdir/cppcheck.xml
+cppcheck $args *.cc *.hh --xml 2>"$outdir/cppcheck.xml"
 
-cppcheck-htmlreport --source-dir=. --title=rdfind --file=$outdir/cppcheck.xml --report-dir=$outdir
+cppcheck-htmlreport --source-dir=. --title=rdfind --file="$outdir/cppcheck.xml" --report-dir="$outdir"
 
 
 #is anything serious found?
-if grep --quiet -v -E '^(style|information|performance):' $outdir/cppcheck.out ; then
- echo $me: cppcheck found serious issues. see $outdir/cppcheck.out
+if grep --quiet -v -E '^(style|information|performance):' "$outdir/cppcheck.out" ; then
+ echo "$me: cppcheck found serious issues. see $outdir/cppcheck.out"
  exit 1
 fi
 

--- a/do_clang_format.sh
+++ b/do_clang_format.sh
@@ -14,8 +14,8 @@ if [ ! -x "$CLANGFORMAT" ] ; then
    echo failed finding clangformat
    exit 1
 else
-   echo found clang format: $CLANGFORMAT
+   echo "found clang format: $CLANGFORMAT"
 fi
 
 find . -maxdepth 1 -type f \( -name "*.h" -o -name "*.cpp" -o -name "*.cc" -o -name "*.hh" \) -print0 | \
-   xargs -0 -n1 $CLANGFORMAT -i
+   xargs -0 -n1 "$CLANGFORMAT" -i

--- a/do_quality_checks.sh
+++ b/do_quality_checks.sh
@@ -34,8 +34,8 @@ set -e
 
 export LANG=
 
-rootdir=$(dirname $0)
-me=$(basename $0)
+rootdir=$(dirname "$0")
+me=$(basename "$0")
 
 #flags to configure, for assert.
 ASSERT=

--- a/testcases/common_funcs.sh
+++ b/testcases/common_funcs.sh
@@ -6,7 +6,7 @@
 #bail out on the first error
 set -e
 
-me=$(basename $0)
+me=$(basename "$0")
 
 
 /bin/echo -n "$me: checking for rdfind ..."
@@ -27,7 +27,7 @@ fi
 rdfind="$VALGRIND $rdfind"
 
 #where is the test scripts dir?
-testscriptsdir=$(dirname $(readlink -f $0))
+testscriptsdir=$(dirname "$(readlink -f "$0")")
 
 
 dbgecho() {
@@ -56,21 +56,22 @@ if [ -z $KEEPTEMPDIR ] ; then
    trap cleanup INT QUIT EXIT
 fi
 
-[ -d $datadir ]
-cd $datadir
+[ -d "$datadir" ]
+cd "$datadir"
 
 reset_teststate() {
    cd /
    rm -rf "$datadir"
-   mkdir -p $datadir
+   mkdir -p "$datadir"
    cd "$datadir"
 }
 
 
 verify() {
-   if ! $@ ; then
-      echo "failed asserting $@"
+   if ! "$@" ; then
+      echo "failed asserting $*"
       exit 1
+
    fi
 }
 
@@ -81,10 +82,10 @@ DISORDERED_ROOT=$datadir/disordered_root
 # do we have a working disorder fs?
 hasdisorderfs=false
 if which disorderfs fusermount >/dev/null 2>&1; then
-   mkdir -p $DISORDERED_MNT $DISORDERED_ROOT
-   if disorderfs $DISORDERED_ROOT $DISORDERED_MNT >/dev/null 2>&1 ; then
+   mkdir -p "$DISORDERED_MNT" "$DISORDERED_ROOT"
+   if disorderfs "$DISORDERED_ROOT" "$DISORDERED_MNT" >/dev/null 2>&1 ; then
       # "Sälj inte skinnet förrän björnen är skjuten - Don't count your chickens until they're hatched"
-      fusermount -z -u $DISORDERED_MNT
+      fusermount -z -u "$DISORDERED_MNT"
       hasdisorderfs=true
    fi
 fi

--- a/testcases/hardlink_fails.sh
+++ b/testcases/hardlink_fails.sh
@@ -13,16 +13,16 @@ reset_teststate
 files="a subdir/b c some/deeply/nested/subdir/d"
 nfiles=4
 for n in $files ; do
-   mkdir -p $(dirname $datadir/$n)
-   echo "hello hardlink" > $datadir/$n
+   mkdir -p "$(dirname "$datadir/$n")"
+   echo "hello hardlink" > "$datadir/$n"
 done
 
 #eliminate them.
-$rdfind -makehardlinks true $datadir/
+$rdfind -makehardlinks true "$datadir/"
 
 #make sure one is a hard link to the other.
 for n in $files ; do
-   nhardlinks=$(stat -c %h $datadir/$n)
+   nhardlinks=$(stat -c %h "$datadir/$n")
    if [ $nhardlinks -ne $nfiles ] ; then
       dbgecho "expected $nfiles hardlinks, got $nhardlinks"
       exit 1
@@ -43,15 +43,15 @@ fi
 
 reset_teststate
 system_file=$(which ls)
-cp $system_file .
-$rdfind -makehardlinks true . $system_file 2>&1 |tee rdfind.out
+cp "$system_file" .
+$rdfind -makehardlinks true . "$system_file" 2>&1 |tee rdfind.out
 if ! grep -iq "failed" rdfind.out ; then
    dbgecho "expected failure when trying to make hardlink on system partition"
    exit 1
 fi
 
 #make sure that our own copy is still there
-if [ ! -e $(basename $system_file) ] ; then
+if [ ! -e "$(basename "$system_file")" ] ; then
    dbgecho file is missing, rdfind should not have removed it!
    exit 1
 fi

--- a/testcases/md5collisions.sh
+++ b/testcases/md5collisions.sh
@@ -10,7 +10,7 @@ reset_teststate
 
 #check md5 collision files
 mkdir md5coll
-cp $testscriptsdir/md5collisions/*.ps md5coll
+cp "$testscriptsdir"/md5collisions/*.ps md5coll
 sync
 
 #make sure nothing happens when using sha

--- a/testcases/sha1collisions.sh
+++ b/testcases/sha1collisions.sh
@@ -9,7 +9,7 @@ set -e
 reset_teststate
 
 #unpack collisions example from https://shattered.it/static/shattered.pdf
-base64 --decode <$testscriptsdir/sha1collisions/coll.tar.bz2.b64 |tar xvfj -
+base64 --decode <"$testscriptsdir"/sha1collisions/coll.tar.bz2.b64 |tar xvfj -
 
 #make sure nothing happens when using sha256
 $rdfind  -checksum sha256 -deleteduplicates true . 2>&1 |tee rdfind.out

--- a/testcases/symlinking_action.sh
+++ b/testcases/symlinking_action.sh
@@ -12,12 +12,12 @@ reset_teststate
 files="first subdir/b c some/deeply/nested/subdir/d"
 nfiles=4
 for n in $files ; do
-   mkdir -p $(dirname $datadir/$n)
-   echo "hello symlink" > $datadir/$n
+   mkdir -p "$(dirname "$datadir/$n")"
+   echo "hello symlink" > "$datadir/$n"
 done
 
 #eliminate them.
-$rdfind -makesymlinks true $datadir/first $datadir/
+$rdfind -makesymlinks true "$datadir/first" "$datadir/"
 
 #make sure the first one is untouched (it has the highest rank), and the rest are symlinks.
 export LANG=
@@ -52,15 +52,15 @@ fi
 
 reset_teststate
 system_file=$(which ls)
-cp $system_file .
-$rdfind -makesymlinks true . $system_file 2>&1 |tee rdfind.out
+cp "$system_file" .
+$rdfind -makesymlinks true . "$system_file" 2>&1 |tee rdfind.out
 if ! grep -iq "failed to make symlink" rdfind.out ; then
    dbgecho "did not get the expected error message. see for yourself above."
    exit 1
 fi
 
 #make sure that our own copy is still there
-if [ ! -e $(basename $system_file) ] ; then
+if [ ! -e "$(basename "$system_file")" ] ; then
    dbgecho file is missing, rdfind should not have removed it!
    exit 1
 fi
@@ -73,13 +73,13 @@ dbgecho passed the test with trying to write to a system directory
 # argument 1 is path to file 1. argument 2 is path to file 2.
 pathsimplification() {
    reset_teststate
-   mkdir -p $(dirname $1) && echo "simplification test" >$1
-   mkdir -p $(dirname $2) && echo "simplification test" >$2
+   mkdir -p "$(dirname "$1")" && echo "simplification test" >"$1"
+   mkdir -p "$(dirname "$2")" && echo "simplification test" >"$2"
 
    #dbgecho "state before (args  $1 $2)"
    #tree
 
-   $rdfind -makesymlinks true $1 $2 2>&1 |tee rdfind.out
+   $rdfind -makesymlinks true "$1" "$2" 2>&1 |tee rdfind.out
    # $2 should be a symlink to $1
    if [ x"$(stat -c %F "$1")" != x"regular file" ] ; then
       dbgecho "expected file $1 to be a regular file"
@@ -96,8 +96,8 @@ pathsimplification() {
       exit 1
    fi
    #switching directory should still give the correct answer
-   cd $(dirname $2)
-   inodefor2=$(stat --dereference -c %i $(basename "$2"))
+   cd "$(dirname "$2")"
+   inodefor2=$(stat --dereference -c %i "$(basename "$2")")
    if [ $inodefor1 != $inodefor2 ] ; then
       dbgecho "inode mismatch $inodefor1 vs $inodefor2"
       exit 1
@@ -116,10 +116,10 @@ pathsimplification subdir1/../a subdir2/b
 pathsimplification subdir1/../a subdir2/./././b
 pathsimplification subdir2/./././b subdir1/../a
 pathsimplification a subdir2/./././b
-pathsimplification $(pwd)/a b
-pathsimplification a $(pwd)/b
-pathsimplification $(pwd)/a $(pwd)/b
-pathsimplification $(pwd)/subdir/../a $(pwd)/b
+pathsimplification "$(pwd)/a" b
+pathsimplification a "$(pwd)/b"
+pathsimplification "$(pwd)/a" "$(pwd)/b"
+pathsimplification "$(pwd)/subdir/../a" "$(pwd)/b"
 pathsimplification ./a b
 pathsimplification ./a ./b
 pathsimplification a ./b

--- a/testcases/verify_deterministic_operation.sh
+++ b/testcases/verify_deterministic_operation.sh
@@ -16,8 +16,8 @@ fi
 
 #unmount disordered
 unmount_disordered() {
-   if [ -d $DISORDERED_MNT ]; then
-      if ! fusermount --quiet -u $DISORDERED_MNT ; then
+   if [ -d "$DISORDERED_MNT" ]; then
+      if ! fusermount --quiet -u "$DISORDERED_MNT" ; then
          dbgecho failed unmounting disordered
       fi
    fi
@@ -28,17 +28,17 @@ DISORDERED_FLAGS_ASC="--shuffle-dirents=no --sort-dirents=yes --reverse-dirents=
 DISORDERED_FLAGS_DESC="--shuffle-dirents=no --sort-dirents=yes --reverse-dirents=yes"
 DISORDERED_FLAGS=$DISORDERED_FLAGS_RANDOM
 mount_disordered() {
-   mkdir -p $DISORDERED_MNT
-   mkdir -p $DISORDERED_ROOT
-   disorderfs $DISORDERED_FLAGS $DISORDERED_ROOT $DISORDERED_MNT >/dev/null
+   mkdir -p "$DISORDERED_MNT"
+   mkdir -p "$DISORDERED_ROOT"
+   disorderfs $DISORDERED_FLAGS "$DISORDERED_ROOT" "$DISORDERED_MNT" >/dev/null
 }
 
 #create
 cr8() {
    while [ $# -gt 0 ] ; do
-      mkdir -p $(dirname $1)
+      mkdir -p "$(dirname "$1")"
       # make sure the file is longer than what fits in the byte buffer
-      head -c1000 /dev/zero >$1
+      head -c1000 /dev/zero >"$1"
       shift
    done
 }
@@ -46,17 +46,17 @@ local_reset() {
    unmount_disordered
    reset_teststate
    mount_disordered
-   cr8 $@
+   cr8 "$@"
 }
 
 #sets global variable outcome to which file was preserved, a or b.
 #$1 - value of -deterministic flag (true or false)
 run_outcome() {
-   local_reset $DISORDERED_MNT/a $DISORDERED_MNT/b
-   $rdfind -deterministic $1 -deleteduplicates true $DISORDERED_MNT >rdfind.out
-   if [ -f $DISORDERED_MNT/a -a ! -e $DISORDERED_MNT/b ] ; then
+   local_reset "$DISORDERED_MNT/a" "$DISORDERED_MNT/b"
+   $rdfind -deterministic $1 -deleteduplicates true "$DISORDERED_MNT" >rdfind.out
+   if [ -f "$DISORDERED_MNT/a" -a ! -e "$DISORDERED_MNT/b" ] ; then
       outcome=a
-   elif  [ ! -e $DISORDERED_MNT/a -a -f $DISORDERED_MNT/b ] ; then
+   elif  [ ! -e "$DISORDERED_MNT/a" -a -f "$DISORDERED_MNT/b" ] ; then
       outcome=b
    else
       dbgecho "bad result! test failed!"

--- a/testcases/verify_ranking.sh
+++ b/testcases/verify_ranking.sh
@@ -12,27 +12,27 @@ unmount_disordered() {
    if ! $hasdisorderfs ; then
       return
    fi
-   if [ -d $DISORDERED_MNT ]; then
-      if ! fusermount --quiet -z -u $DISORDERED_MNT ; then
+   if [ -d "$DISORDERED_MNT" ]; then
+      if ! fusermount --quiet -z -u "$DISORDERED_MNT" ; then
          dbgecho failed unmounting disordered
       fi
    fi
 }
 
 mount_disordered() {
-   mkdir -p $DISORDERED_MNT $DISORDERED_ROOT
+   mkdir -p "$DISORDERED_MNT" "$DISORDERED_ROOT"
    if ! $hasdisorderfs ; then
       return
    fi
-   disorderfs --sort-dirents=yes --reverse-dirents=no $DISORDERED_ROOT $DISORDERED_MNT >/dev/null
+   disorderfs --sort-dirents=yes --reverse-dirents=no "$DISORDERED_ROOT" "$DISORDERED_MNT" >/dev/null
 }
 
 #create
 cr8() {
    while [ $# -gt 0 ] ; do
-      mkdir -p $(dirname $1)
+      mkdir -p "$(dirname "$1")"
       # make sure the file is longer than what fits in the byte buffer
-      head -c1000 /dev/zero >$1
+      head -c1000 /dev/zero >"$1"
       shift
    done
 }
@@ -41,7 +41,7 @@ local_reset() {
    unmount_disordered
    reset_teststate
    mount_disordered
-   cr8 $@
+   cr8 "$@"
 }
 
 
@@ -97,16 +97,16 @@ dbgecho "tests for rule 2 passed ok"
 #apt install disorderfs, and make sure you are member of the fuse group.
 if $hasdisorderfs ; then
 
-   local_reset $DISORDERED_MNT/a $DISORDERED_MNT/b
-   $rdfind -deleteduplicates true $DISORDERED_MNT >rdfind.out
-   [ -f $DISORDERED_MNT/a ]
-   [ ! -e $DISORDERED_MNT/b ]
+   local_reset "$DISORDERED_MNT/a" "$DISORDERED_MNT/b"
+   $rdfind -deleteduplicates true "$DISORDERED_MNT" >rdfind.out
+   [ -f "$DISORDERED_MNT/a" ]
+   [ ! -e "$DISORDERED_MNT/b" ]
    dbgecho "tests for rule 3 passed ok"
 
-   local_reset $DISORDERED_MNT/b $DISORDERED_MNT/a
-   $rdfind -deleteduplicates true $DISORDERED_MNT >rdfind.out
-   [ -f $DISORDERED_MNT/a ]
-   [ ! -e $DISORDERED_MNT/b ]
+   local_reset "$DISORDERED_MNT/b" "$DISORDERED_MNT/a"
+   $rdfind -deleteduplicates true "$DISORDERED_MNT" >rdfind.out
+   [ -f "$DISORDERED_MNT/a" ]
+   [ ! -e "$DISORDERED_MNT/b" ]
    dbgecho "tests for rule 3 passed ok"
 else
    dbgecho "could not execute tests for rule 3 - please install disorderfs"


### PR DESCRIPTION
Improve the scripts to make them more resiliant to filepaths with whitespace characters (spaces, tabs, newlines). Before these changes, the shell would exit with a cryptic/mysterious message.